### PR TITLE
Update Go and GH Action versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.13
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -38,24 +38,18 @@ jobs:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt
     
-  imports:
-    name: Imports
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
-      with:
-        run: imports
-        token: ${{ secrets.GITHUB_TOKEN }}
-        
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@master
-    - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
-      with:
-        run: lint
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: check
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          version: 'v1.52'
+          only-new-issues: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
       run: go test -v ./... -coverprofile coverage.txt
       
     - name: Upload Coverage report to CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt

--- a/base_serializer.go
+++ b/base_serializer.go
@@ -173,6 +173,7 @@ func (bs *baseSerializer) handleAnnotationsEnd(ionValue hashValue, isContainer b
 	return nil
 }
 
+//nolint:unused
 func (bs *baseSerializer) writeSymbol(val string) error {
 	symbol, err := ion.NewSymbolToken(ion.V1SystemSymbolTable, val)
 	if err != nil {

--- a/crypto_hasher.go
+++ b/crypto_hasher.go
@@ -24,8 +24,8 @@ import (
 
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/blake2s"
-	"golang.org/x/crypto/md4"
-	"golang.org/x/crypto/ripemd160"
+	"golang.org/x/crypto/md4"       //nolint: staticcheck
+	"golang.org/x/crypto/ripemd160" //nolint: staticcheck
 	"golang.org/x/crypto/sha3"
 )
 
@@ -35,23 +35,23 @@ type Algorithm string
 // Constants for each of the algorithm names supported.
 const (
 	MD4        Algorithm = "MD4"
-	MD5                  = "MD5"
-	SHA1                 = "SHA1"
-	SHA224               = "SHA224"
-	SHA256               = "SHA256"
-	SHA384               = "SHA384"
-	SHA512               = "SHA512"
-	RIPEMD160            = "RIPMD160"
-	SHA3s224             = "SHA3_224"
-	SHA3s256             = "SHA3_256"
-	SHA3s384             = "SHA3_384"
-	SHA3s512             = "SHA3_512"
-	SHA512s224           = "SHA512_224"
-	SHA512s256           = "SHA512_256"
-	BLAKE2s256           = "BLAKE2s_256"
-	BLAKE2b256           = "BLAKE2b_256"
-	BLAKE2b384           = "BLAKE2b_384"
-	BLAKE2b512           = "BLAKE2b_512"
+	MD5        Algorithm = "MD5"
+	SHA1       Algorithm = "SHA1"
+	SHA224     Algorithm = "SHA224"
+	SHA256     Algorithm = "SHA256"
+	SHA384     Algorithm = "SHA384"
+	SHA512     Algorithm = "SHA512"
+	RIPEMD160  Algorithm = "RIPMD160"
+	SHA3s224   Algorithm = "SHA3_224"
+	SHA3s256   Algorithm = "SHA3_256"
+	SHA3s384   Algorithm = "SHA3_384"
+	SHA3s512   Algorithm = "SHA3_512"
+	SHA512s224 Algorithm = "SHA512_224"
+	SHA512s256 Algorithm = "SHA512_256"
+	BLAKE2s256 Algorithm = "BLAKE2s_256"
+	BLAKE2b256 Algorithm = "BLAKE2b_256"
+	BLAKE2b384 Algorithm = "BLAKE2b_384"
+	BLAKE2b512 Algorithm = "BLAKE2b_512"
 )
 
 // cryptoHasher computes the hash using given algorithm.

--- a/hash_writer_test.go
+++ b/hash_writer_test.go
@@ -247,14 +247,14 @@ func TestWriteContainers(t *testing.T) {
 
 	assert.NoError(t, ionHashWriter.BeginList(), "Something went wrong executing ionHashWriter.BeginList()")
 
-	sum, err = ionHashWriter.Sum(nil)
+	_, err = ionHashWriter.Sum(nil)
 	assert.Error(t, err, "Expected ionHashWriter.Sum(nil) to return an error")
 	assert.IsType(t, &InvalidOperationError{}, err,
 		"Expected ionHashWriter.Sum(nil) to return an InvalidOperationError")
 
 	assert.NoError(t, ionHashWriter.WriteBool(true), "Something went wrong executing ionHashWriter.WriteBool(true)")
 
-	sum, err = ionHashWriter.Sum(nil)
+	_, err = ionHashWriter.Sum(nil)
 	assert.Error(t, err, "Expected ionHashWriter.Sum(nil) to return an error")
 	assert.IsType(t, &InvalidOperationError{}, err,
 		"Expected ionHashWriter.Sum(nil) to return an InvalidOperationError")

--- a/naughty_strings_test.go
+++ b/naughty_strings_test.go
@@ -146,8 +146,8 @@ func newTestValue(ion string) testValue {
 	if strings.HasPrefix(ion, prefix) {
 		validIon = true
 		ion = ion[len(prefix):]
-	} else if strings.HasPrefix(ion, invalidPrefix) {
-		ion = ion[len(invalidPrefix):]
+	} else {
+		ion = strings.TrimPrefix(ion, invalidPrefix)
 	}
 
 	return testValue{ionPrefix: prefix, invalidIonPrefix: invalidPrefix, ion: ion, validIon: validIon}

--- a/struct_serializer.go
+++ b/struct_serializer.go
@@ -68,6 +68,7 @@ func (ss *structSerializer) stepOut() error {
 	return ss.baseSerializer.stepOut()
 }
 
+//nolint:unused
 func (ss *structSerializer) handleAnnotationsBegin(ionValue hashValue) error {
 	return ss.baseSerializer.handleAnnotationsBegin(ionValue, false)
 }


### PR DESCRIPTION
Issue #, if available: n/a

Description of changes:
This PR updates the version of Go used for building to 1.19 (which will probably be unsupported in a few months). I didn't jump to 1.20 because I'm not up to speed on all of the changes in recent versions. Go only supports the last two releases, so this catches us up to a supported version.

This PR also updates used actions to newer versions. We had some warnings about actions that were deprecated due to the nodejs version they used. So these updates will catch us up there.

Prior to this PR we used [grandcolline/golang-github-actions](https://github.com/grandcolline/golang-github-actions) to run `imports` and `lint`, but the project appears to be abandoned and has not been updated in a couple years. This PR removes that action and uses [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) instead.

This PR addresses all of the linting issues that were found by golangci-lint.

A potential follow-up would be to get `imports` (or equivalent) back in, and checking `gofmt`. I'll see about doing that later in the week.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
