### PR TITLE
Address issues with dependabot #80

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.19
-      uses: actions/setup-go@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: stable
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -33,7 +33,7 @@ jobs:
       run: go test -v ./... -coverprofile coverage.txt
       
     - name: Upload Coverage report to CodeCov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt
@@ -44,12 +44,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
-      - uses: actions/checkout@v3
+          go-version: stable
+      - uses: actions/checkout@v4
       - name: check
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.52'
+          version: 'v1.60'
           only-new-issues: true


### PR DESCRIPTION
Issue #, if available: Failed build in #80

Description of changes:
The dependabot PR #80 failed due to a couple undefined symbols in `x/crypto/sha3`. The symbols were undefined due to the version of go being used to compile them (version 1.19), which is outside of the supported Go versions.

The go team supports the most recent stable version (1.23.x), along with the minor version prior to it (referred to as oldstable, currently 1.22.x). Our actions had locked to 1.19, and unfortunately some of our dependencies explicitly require >=1.20.

This PR updates the go version installed to lean on `setup-go`'s ability to install the current stable, or oldstable, release to always install the current stable. This should eliminate the need for us to update the go version from now on.

This PR also updates the actions that we use, since some of them are also deprecated.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
