### PR TITLE
Address lint issues: deprecated ioutil.ReadFile & Read with -1 count

### DIFF
--- a/cmd/ion-hash.go
+++ b/cmd/ion-hash.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -48,7 +47,7 @@ func main() {
 	algorithm := os.Args[1]
 	fileName := os.Args[2]
 
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	check(err)
 
 	ionReader := ion.NewReaderBytes(data)

--- a/hash_reader_test.go
+++ b/hash_reader_test.go
@@ -16,7 +16,7 @@
 package ionhash
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/amzn/ion-go/ion"
@@ -87,7 +87,7 @@ func TestConsumeRemainderNext(t *testing.T) {
 }
 
 func TestIonReaderContract(t *testing.T) {
-	file, err := ioutil.ReadFile("ion-hash-test/ion_hash_tests.ion")
+	file, err := os.ReadFile("ion-hash-test/ion_hash_tests.ion")
 	require.NoError(t, err, "Something went wrong loading ion_hash_tests.ion")
 
 	reader := ion.NewReaderBytes(file)

--- a/hash_writer_test.go
+++ b/hash_writer_test.go
@@ -17,8 +17,8 @@ package ionhash
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -333,7 +333,7 @@ func TestExtraEndContainer(t *testing.T) {
 }
 
 func TestIonWriterContractWriteValue(t *testing.T) {
-	file, err := ioutil.ReadFile("ion-hash-test/ion_hash_tests.ion")
+	file, err := os.ReadFile("ion-hash-test/ion_hash_tests.ion")
 	require.NoError(t, err, "Something went wrong loading ion_hash_tests.ion")
 
 	expected := ExerciseWriter(t, ion.NewReaderBytes(file), false, writeFromReaderToWriterAfterNext)
@@ -348,7 +348,7 @@ func TestIonWriterContractWriteValue(t *testing.T) {
 }
 
 func TestIonWriterContractWriteValues(t *testing.T) {
-	file, err := ioutil.ReadFile("ion-hash-test/ion_hash_tests.ion")
+	file, err := os.ReadFile("ion-hash-test/ion_hash_tests.ion")
 	require.NoError(t, err, "Something went wrong loading ion_hash_tests.ion")
 
 	expected := ExerciseWriter(t, ion.NewReaderBytes(file), false, writeFromReaderToWriter)

--- a/ion_hash_test.go
+++ b/ion_hash_test.go
@@ -17,7 +17,7 @@ package ionhash
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -80,7 +80,7 @@ func TraverseReader(t *testing.T, hr HashReader) {
 func ionHashDataSource(t *testing.T) []testObject {
 	var dataList []testObject
 
-	file, err := ioutil.ReadFile("ion-hash-test/ion_hash_tests.ion")
+	file, err := os.ReadFile("ion-hash-test/ion_hash_tests.ion")
 	require.NoError(t, err, "Something went wrong loading ion_hash_tests.ion")
 
 	reader := ion.NewReaderBytes(file)

--- a/naughty_strings_test.go
+++ b/naughty_strings_test.go
@@ -159,8 +159,8 @@ func (tv *testValue) asIon() string {
 
 func (tv *testValue) asSymbol() string {
 	s := tv.ion
-	s = strings.Replace(s, "\\", "\\\\", -1)
-	s = strings.Replace(s, "'", "\\'", -1)
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "\\'")
 	s = "'" + s + "'"
 
 	return s
@@ -168,8 +168,8 @@ func (tv *testValue) asSymbol() string {
 
 func (tv *testValue) asString() string {
 	s := tv.ion
-	s = strings.Replace(s, "\\", "\\\\", -1)
-	s = strings.Replace(s, "\"", "\\\"", -1)
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
 	s = "\"" + s + "\""
 
 	return s
@@ -177,8 +177,8 @@ func (tv *testValue) asString() string {
 
 func (tv *testValue) asLongString() string {
 	s := tv.ion
-	s = strings.Replace(s, "\\", "\\\\", -1)
-	s = strings.Replace(s, "'", "\\'", -1)
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "\\'")
 	s = "'''" + s + "'''"
 
 	return s


### PR DESCRIPTION
Issue #, if available: #82

Description of changes:
This PR addresses the current linter errors that are showing up in builds. These issues include:
- `io/ioutil` deprecation - This codebase used `ioutil.ReadFile` quite a bit, which has been moved into the `os` package.
- Use `ReplaceAll` instead of `Read` with a count < 0. 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
